### PR TITLE
Fix Process Keys Lambda

### DIFF
--- a/udemy-advanced_serverless_workflow_with_step_functions/lambda_source_code/get_expired_keys.py
+++ b/udemy-advanced_serverless_workflow_with_step_functions/lambda_source_code/get_expired_keys.py
@@ -22,7 +22,7 @@ def get_iam_accounts():
     return iam_accounts
 
 
-def get_expired_keys(event, context):
+def lambda_handler(event, context):
     result = {}
     expired_keys = []
 
@@ -49,8 +49,9 @@ def get_expired_keys(event, context):
     return result
 
 
+# If this was ran locally, what event/context would I pass in? ::thinking::
 def main():
-    print(get_expired_keys("event", "context"))
+    print(lambda_handler("event", "context"))
 
 
 if __name__ == "__main__":

--- a/udemy-advanced_serverless_workflow_with_step_functions/lambda_source_code/get_expired_keys.py
+++ b/udemy-advanced_serverless_workflow_with_step_functions/lambda_source_code/get_expired_keys.py
@@ -2,8 +2,6 @@ import boto3
 from datetime import datetime, timezone
 
 
-# boto3.setup_default_session(profile_name="default")
-
 iam_resource = boto3.resource("iam")
 iam_client = boto3.client("iam")
 
@@ -47,12 +45,3 @@ def lambda_handler(event, context):
                         )
     result["Users"] = expired_keys
     return result
-
-
-# If this was ran locally, what event/context would I pass in? ::thinking::
-def main():
-    print(lambda_handler("event", "context"))
-
-
-if __name__ == "__main__":
-    main()

--- a/udemy-advanced_serverless_workflow_with_step_functions/lambda_source_code/process_expired_keys.py
+++ b/udemy-advanced_serverless_workflow_with_step_functions/lambda_source_code/process_expired_keys.py
@@ -6,7 +6,7 @@ iam_client = boto3.client("iam")
 
 
 def deactivate_user_key(user, key):
-    for tag in iam_client.list_user_tag(UserName=user)["Tag"]:
+    for tag in iam_client.list_user_tags(UserName=user)["Tag"]:
         if tag["Key"].lower() in {"email", "e-mail"}:
             iam_client.update_access_key(
                 UserName=user, AccessKeyId=key, Status="Inactive"

--- a/udemy-advanced_serverless_workflow_with_step_functions/terraform/get_expired_keys-lambda.tf
+++ b/udemy-advanced_serverless_workflow_with_step_functions/terraform/get_expired_keys-lambda.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "get_expired_keys_lambda" {
 
 resource "aws_cloudwatch_log_group" "get_expired_keys_lambda-log_group" {
   name              = "/aws/lambda/${var.get_expired_keys_lambda_name}"
-  retention_in_days = 1
+  retention_in_days = 30
 }
 
 resource "aws_iam_role" "get_expired_keys_lambda_exec_role" {

--- a/udemy-advanced_serverless_workflow_with_step_functions/terraform/get_expired_keys-lambda.tf
+++ b/udemy-advanced_serverless_workflow_with_step_functions/terraform/get_expired_keys-lambda.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "get_expired_keys_lambda" {
   filename         = "../lambda_source_code/get_expired_keys.zip"
   function_name    = var.get_expired_keys_lambda_name
   role             = aws_iam_role.get_expired_keys_lambda_exec_role.arn
-  handler          = "get_expired_keys.get_expired_keys"
+  handler          = "get_expired_keys.lambda_handler"
   timeout          = 120
   source_code_hash = data.archive_file.get_expired_keys_archive.output_base64sha256
   runtime          = "python3.8"

--- a/udemy-advanced_serverless_workflow_with_step_functions/terraform/process_expired_keys-lambda.tf
+++ b/udemy-advanced_serverless_workflow_with_step_functions/terraform/process_expired_keys-lambda.tf
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "process_expired_keys_lambda" {
 
 resource "aws_cloudwatch_log_group" "process_expired_keys_lambda-log_group" {
   name              = "/aws/lambda/${var.process_expired_keys_lambda_name}"
-  retention_in_days = 1
+  retention_in_days = 15
 }
 
 resource "aws_iam_role" "process_expired_keys_lambda_exec_role" {

--- a/udemy-advanced_serverless_workflow_with_step_functions/terraform/process_expired_keys-lambda.tf
+++ b/udemy-advanced_serverless_workflow_with_step_functions/terraform/process_expired_keys-lambda.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "process_expired_keys_lambda" {
   filename         = "../lambda_source_code/process_expired_keys.zip"
   function_name    = var.process_expired_keys_lambda_name
   role             = aws_iam_role.process_expired_keys_lambda_exec_role.arn
-  handler          = "process_expired_keys.process_expired_keys"
+  handler          = "process_expired_keys.lambda_handler"
   timeout          = 120
   source_code_hash = data.archive_file.process_expired_keys_archive.output_base64sha256
   runtime          = "python3.8"
@@ -21,7 +21,7 @@ resource "aws_lambda_function" "process_expired_keys_lambda" {
 
 resource "aws_cloudwatch_log_group" "process_expired_keys_lambda-log_group" {
   name              = "/aws/lambda/${var.process_expired_keys_lambda_name}"
-  retention_in_days = 15
+  retention_in_days = 30
 }
 
 resource "aws_iam_role" "process_expired_keys_lambda_exec_role" {


### PR DESCRIPTION
Correct the lambda handler configured w/ the correct function name in process_expired_keys & use the same lambda handler name in the get_expired_keys lambda as well.

Increase CW logs retention -- storage is cheap.